### PR TITLE
policy: Remove references of Profiles in android.policy.

### DIFF
--- a/core/java/com/android/internal/util/cm/PowerMenuConstants.java
+++ b/core/java/com/android/internal/util/cm/PowerMenuConstants.java
@@ -21,7 +21,6 @@ public class PowerMenuConstants {
     public static final String GLOBAL_ACTION_KEY_POWER = "power";
     public static final String GLOBAL_ACTION_KEY_REBOOT = "reboot";
     public static final String GLOBAL_ACTION_KEY_SCREENSHOT = "screenshot";
-    public static final String GLOBAL_ACTION_KEY_PROFILE = "profile";
     public static final String GLOBAL_ACTION_KEY_AIRPLANE = "airplane";
     public static final String GLOBAL_ACTION_KEY_USERS = "users";
     public static final String GLOBAL_ACTION_KEY_SETTINGS = "settings";
@@ -33,7 +32,6 @@ public class PowerMenuConstants {
         GLOBAL_ACTION_KEY_POWER,
         GLOBAL_ACTION_KEY_REBOOT,
         GLOBAL_ACTION_KEY_SCREENSHOT,
-        GLOBAL_ACTION_KEY_PROFILE,
         GLOBAL_ACTION_KEY_AIRPLANE,
         GLOBAL_ACTION_KEY_USERS,
         GLOBAL_ACTION_KEY_SETTINGS,

--- a/policy/Android.mk
+++ b/policy/Android.mk
@@ -7,8 +7,6 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
             
 LOCAL_MODULE := android.policy
-LOCAL_STATIC_JAVA_LIBRARIES := \
-    org.cyanogenmod.platform.sdk
 
 include $(BUILD_JAVA_LIBRARY)
 

--- a/policy/src/com/android/internal/policy/impl/GlobalActions.java
+++ b/policy/src/com/android/internal/policy/impl/GlobalActions.java
@@ -97,9 +97,6 @@ import android.widget.ImageView.ScaleType;
 import android.widget.ListView;
 import android.widget.TextView;
 
-import cyanogenmod.app.Profile;
-import cyanogenmod.app.ProfileManager;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -138,7 +135,6 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
     private boolean mHasTelephony;
     private boolean mHasVibrator;
     private final boolean mShowSilentToggle;
-    private Profile mChosenProfile;
 
     // Power menu customizations
     String mActions;
@@ -342,31 +338,6 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
                 mItems.add(getSettingsAction());
             } else if (GLOBAL_ACTION_KEY_LOCKDOWN.equals(actionKey)) {
                 mItems.add(getLockdownAction());
-            } else if (GLOBAL_ACTION_KEY_PROFILE.equals(actionKey)) {
-                if (!mProfilesEnabled) continue;
-                mItems.add(
-                        new ProfileChooseAction() {
-                            public void onPress() {
-                                createProfileDialog();
-                            }
-
-                            public boolean onLongPress() {
-                                return true;
-                            }
-
-                            public boolean showDuringKeyguard() {
-                                return false;
-                            }
-
-                            public boolean showBeforeProvisioning() {
-                                return false;
-                            }
-
-                            public CharSequence getLabelForAccessibility(Context context) {
-                                return null;
-                            }
-
-                        });
             } else {
                 Log.e(TAG, "Invalid global action key " + actionKey);
             }
@@ -403,80 +374,6 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
         dialog.setOnDismissListener(this);
 
         return dialog;
-    }
-
-    private void createProfileDialog() {
-        final ProfileManager profileManager = ProfileManager.getInstance(mContext);
-
-        final Profile[] profiles = profileManager.getProfiles();
-        UUID activeProfile = profileManager.getActiveProfile().getUuid();
-        final CharSequence[] names = new CharSequence[profiles.length];
-
-        int i = 0;
-        int checkedItem = 0;
-
-        for (Profile profile : profiles) {
-            if (profile.getUuid().equals(activeProfile)) {
-                checkedItem = i;
-                mChosenProfile = profile;
-            }
-            names[i++] = profile.getName();
-        }
-
-        final AlertDialog.Builder ab = new AlertDialog.Builder(getUiContext());
-
-        AlertDialog dialog = ab.setSingleChoiceItems(names, checkedItem,
-                new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int which) {
-                       if (which < 0)
-                            return;
-                        mChosenProfile = profiles[which];
-                        profileManager.setActiveProfile(mChosenProfile.getUuid());
-                        dialog.cancel();
-                    }
-                }).create();
-        dialog.getWindow().setType(WindowManager.LayoutParams.TYPE_SYSTEM_DIALOG);
-        dialog.show();
-    }
-
-     /**
-     * A single press action maintains no state, just responds to a press
-     * and takes an action.
-     */
-    private abstract class ProfileChooseAction implements Action {
-        private ProfileManager mProfileManager;
-
-        protected ProfileChooseAction() {
-            mProfileManager = ProfileManager.getInstance(mContext);
-        }
-
-        public boolean isEnabled() {
-            return true;
-        }
-
-        abstract public void onPress();
-
-        public View create(
-                Context context, View convertView, ViewGroup parent, LayoutInflater inflater) {
-            View v = inflater.inflate(R.layout.global_actions_item, parent, false);
-
-            ImageView icon = (ImageView) v.findViewById(R.id.icon);
-            TextView messageView = (TextView) v.findViewById(R.id.message);
-
-            TextView statusView = (TextView) v.findViewById(R.id.status);
-            if (statusView != null) {
-                statusView.setVisibility(View.VISIBLE);
-                statusView.setText(mProfileManager.getActiveProfile().getName());
-            }
-            if (icon != null) {
-                icon.setImageDrawable(context.getDrawable(R.drawable.ic_lock_profile));
-            }
-            if (messageView != null) {
-                messageView.setText(R.string.global_action_choose_profile);
-            }
-
-            return v;
-        }
     }
 
     private final class PowerAction extends SinglePressAction implements LongPressAction {


### PR DESCRIPTION
  We can't reference the CMSDK within a jar that is exported in the
  BOOTCLASSPATH, otherwise we end up overriding the 3rd party
  applications classloaded jar and causing various issues during
  runtime.

Change-Id: Idcbd8f33db89efe55a3b9e5f4ebe6dd47f812e00
