### PR TITLE
Themes: don't recreateDefaults on typeface when locale changes

### DIFF
--- a/core/java/android/app/ActivityThread.java
+++ b/core/java/android/app/ActivityThread.java
@@ -4157,7 +4157,9 @@ public final class ActivityThread {
             boolean hasFontConfigChange = ((configDiff & ActivityInfo.CONFIG_THEME_FONT) != 0);
             if (hasLocaleConfigChange || hasFontConfigChange) {
                 Canvas.freeTextLayoutCaches();
-                Typeface.recreateDefaults();
+                if (hasFontConfigChange) {
+                    Typeface.recreateDefaults();
+                }
                 if (DEBUG_CONFIGURATION) Slog.v(TAG, "Cleared TextLayout Caches");
             }
         }


### PR DESCRIPTION
When changing the device locales, we don't need to call recreateDefaults()
every time the locale config has changed, as it is a very expensive
operation.

Change-Id: Iada86642145aa48772e70e89786e482640c75474
Signed-off-by: Roman Birg roman@cyngn.com
