### PR TITLE
SystemUI: do not load header bar if boot isn't complete

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/recents/AlternateRecentsComponent.java
+++ b/packages/SystemUI/src/com/android/systemui/recents/AlternateRecentsComponent.java
@@ -158,6 +158,7 @@ public class AlternateRecentsComponent implements ActivityOptions.OnAnimationSta
     TaskStackListenerImpl mTaskStackListener;
     RecentsOwnerEventProxyReceiver mProxyBroadcastReceiver;
     boolean mBootCompleted;
+    boolean mDelayLoadTilBoot;
     boolean mStartAnimationTriggered;
     boolean mCanReuseTaskStackViews = true;
 
@@ -217,6 +218,14 @@ public class AlternateRecentsComponent implements ActivityOptions.OnAnimationSta
     public void onStart() {
         // Initialize some static datastructures
         TaskStackViewLayoutAlgorithm.initializeCurve();
+        if (mBootCompleted) {
+            load();
+        } else {
+            mDelayLoadTilBoot = true;
+        }
+    }
+
+    private void load() {
         // Load the header bar layout
         reloadHeaderBarLayout(true);
 
@@ -234,6 +243,12 @@ public class AlternateRecentsComponent implements ActivityOptions.OnAnimationSta
 
     public void onBootCompleted() {
         mBootCompleted = true;
+
+        if (mDelayLoadTilBoot) {
+            mDelayLoadTilBoot = false;
+
+            load();
+        }
     }
 
     /** Shows the Recents. */


### PR DESCRIPTION
Sometimes during OOBE this header bar will bind the search widget
before boot is complete. This will cause a force close due to:
java.lang.IllegalStateException: Cannot broadcast before boot completed

CYNGNOS-263

Change-Id: Ib235c4b7af87007ba0d57f89ed79c80fb263eacd
