### PR TITLE
Add support for Samsung extended AGPS

### DIFF
--- a/services/core/java/com/android/server/location/GpsLocationProvider.java
+++ b/services/core/java/com/android/server/location/GpsLocationProvider.java
@@ -2142,7 +2142,7 @@ public class GpsLocationProvider implements LocationProviderInterface {
                     type = AGPS_REF_LOCATION_TYPE_GSM_CELLID;
                 }
                 native_agps_set_ref_location_cellid(type, mcc, mnc,
-                        gsm_cell.getLac(), gsm_cell.getCid());
+                        gsm_cell.getLac(), gsm_cell.getPsc(), gsm_cell.getCid());
             } else {
                 Log.e(TAG,"Error getting cell location info.");
             }
@@ -2400,7 +2400,7 @@ public class GpsLocationProvider implements LocationProviderInterface {
 
     // AGPS ril suport
     private native void native_agps_set_ref_location_cellid(int type, int mcc, int mnc,
-            int lac, int cid);
+            int lac, int psc, int cid);
     private native void native_agps_set_id(int type, String setid);
 
     private native void native_update_network_state(boolean connected, int type,

--- a/services/core/jni/com_android_server_location_GpsLocationProvider.cpp
+++ b/services/core/jni/com_android_server_location_GpsLocationProvider.cpp
@@ -628,7 +628,7 @@ static jint android_location_GpsLocationProvider_read_sv_status(JNIEnv* env, job
 }
 
 static void android_location_GpsLocationProvider_agps_set_reference_location_cellid(JNIEnv* env,
-        jobject obj, jint type, jint mcc, jint mnc, jint lac, jint cid)
+        jobject obj, jint type, jint mcc, jint mnc, jint lac, jint psc, jint cid)
 {
     AGpsRefLocation location;
 
@@ -644,6 +644,9 @@ static void android_location_GpsLocationProvider_agps_set_reference_location_cel
             location.u.cellID.mcc = mcc;
             location.u.cellID.mnc = mnc;
             location.u.cellID.lac = lac;
+#ifdef AGPS_USE_PSC
+            location.u.cellID.psc = psc;
+#endif
             location.u.cellID.cid = cid;
             break;
         default:
@@ -1463,7 +1466,7 @@ static JNINativeMethod sMethods[] = {
             "(ILjava/lang/String;)V",
             (void*)android_location_GpsLocationProvider_agps_set_id},
     {"native_agps_set_ref_location_cellid",
-            "(IIIII)V",
+            "(IIIIII)V",
             (void*)android_location_GpsLocationProvider_agps_set_reference_location_cellid},
     {"native_set_agps_server",
             "(ILjava/lang/String;I)V",


### PR DESCRIPTION
The AGPS implementation in the GPS chipset used in some Samsung devices
(i9100, i9300) can make use of the Psc field. Adapt the relevant
functions hiding the changes incompatible with other devices under the
AGPS_USE_PSC #define.

Credit to Qaweck from xda-developers forum for finding the meaning
of the field.

Change-Id: Ie4691c79ca379a1f5c0a87500c1b06b56ae7ac0d
