### PR TITLE
Multiple LEDs [3/3]: Illumination Bars support

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -2829,6 +2829,13 @@ public final class Settings {
                 "notification_light_brightness_level";
 
         /**
+         * Whether to use the all the LEDs for the notifications or just one.
+         * @hide
+         */
+        public static final String NOTIFICATION_LIGHT_MULTIPLE_LEDS_ENABLE =
+                "notification_light_multiple_leds_enable";
+
+        /**
          * Whether to allow notifications with the screen on or DayDreams.
          * The value is boolean (1 or 0). Default will always be false.
          * @hide
@@ -3647,6 +3654,7 @@ public final class Settings {
             NONE_IS_SILENT,
             ALLOW_LIGHTS,
             NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL,
+            NOTIFICATION_LIGHT_MULTIPLE_LEDS_ENABLE,
             NOTIFICATION_LIGHT_SCREEN_ON
         };
 

--- a/core/res/res/values/cm_symbols.xml
+++ b/core/res/res/values/cm_symbols.xml
@@ -190,6 +190,7 @@
     <java-symbol type="bool" name="config_multiColorNotificationLed" />
     <java-symbol type="bool" name="config_intrusiveBatteryLed" />
     <java-symbol type="bool" name="config_multiColorBatteryLed" />
+    <java-symbol type="bool" name="config_multipleNotificationLeds" />
     <java-symbol type="array" name="notification_light_package_mapping" />
     <java-symbol type="array" name="config_notificationNoAlertsVibePattern" />
 

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -825,6 +825,10 @@
          Used to decide if the user can change the colors -->
     <bool name="config_multiColorBatteryLed">false</bool>
 
+    <!-- Does the device have multiple LEDs ?
+         Used to decide if the user can change the multiple LEDs settings -->
+    <bool name="config_multipleNotificationLeds">false</bool>
+
     <!-- Do the battery/notification LEDs support pulsing?
          Used to decide if we show pulse settings -->
     <bool name="config_ledCanPulse">true</bool>

--- a/packages/SettingsProvider/res/values/defaults.xml
+++ b/packages/SettingsProvider/res/values/defaults.xml
@@ -71,6 +71,10 @@
          on devices equiped with configurable LED controller -->
     <integer name="def_notification_brightness_level">255</integer>
 
+    <!-- Default value for whether or not to use multiple notification LEDs
+         on devices equiped with more than one LED -->
+    <bool name="def_notification_multiple_leds">false</bool>
+
     <bool name="def_mount_play_notification_snd">true</bool>
     <bool name="def_mount_ums_autostart">false</bool>
     <bool name="def_mount_ums_prompt">true</bool>

--- a/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
@@ -2553,6 +2553,9 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             loadIntegerSetting(stmt, Settings.System.NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL,
                     R.integer.def_notification_brightness_level);
 
+            loadBooleanSetting(stmt, Settings.System.NOTIFICATION_LIGHT_MULTIPLE_LEDS_ENABLE,
+                    R.bool.def_notification_multiple_leds);
+
             loadBooleanSetting(stmt, Settings.System.SYSTEM_PROFILES_ENABLED,
                     R.bool.def_system_profiles_enabled);
 

--- a/services/core/java/com/android/server/BatteryService.java
+++ b/services/core/java/com/android/server/BatteryService.java
@@ -157,6 +157,9 @@ public final class BatteryService extends SystemService {
     private boolean mAdjustableNotificationLedBrightness;
     private int mNotificationLedBrightnessLevel = LIGHT_BRIGHTNESS_MAXIMUM;
 
+    private boolean mMultipleNotificationLeds;
+    private boolean mMultipleLedsEnabled = false;
+
     private int mLowBatteryWarningLevel;
     private int mLowBatteryCloseWarningLevel;
     private int mShutdownBatteryTemperature;
@@ -940,6 +943,10 @@ public final class BatteryService extends SystemService {
             mAdjustableNotificationLedBrightness = context.getResources().getBoolean(
                     com.android.internal.R.bool.config_adjustableNotificationLedBrightness);
 
+            // Does the Device have multiple LEDs ?
+            mMultipleNotificationLeds = context.getResources().getBoolean(
+                    com.android.internal.R.bool.config_multipleNotificationLeds);
+
             mBatteryLedOn = context.getResources().getInteger(
                     com.android.internal.R.integer.config_notificationsBatteryLedOn);
             mBatteryLedOff = context.getResources().getInteger(
@@ -962,7 +969,8 @@ public final class BatteryService extends SystemService {
                 // No lights if explicitly disabled
                 mBatteryLight.turnOff();
             } else if (level < mLowBatteryWarningLevel) {
-                mBatteryLight.setModes(mNotificationLedBrightnessLevel);
+                mBatteryLight.setModes(mNotificationLedBrightnessLevel,
+                        mMultipleLedsEnabled);
                 if (status == BatteryManager.BATTERY_STATUS_CHARGING) {
                     // Battery is charging and low
                     mBatteryLight.setColor(mBatteryLowARGB);
@@ -976,7 +984,8 @@ public final class BatteryService extends SystemService {
                 }
             } else if (status == BatteryManager.BATTERY_STATUS_CHARGING
                     || status == BatteryManager.BATTERY_STATUS_FULL) {
-                mBatteryLight.setModes(mNotificationLedBrightnessLevel);
+                mBatteryLight.setModes(mNotificationLedBrightnessLevel,
+                        mMultipleLedsEnabled);
                 if (status == BatteryManager.BATTERY_STATUS_FULL || level >= 90) {
                     // Battery is full or charging and nearly full
                     mBatteryLight.setColor(mBatteryFullARGB);
@@ -1112,6 +1121,13 @@ public final class BatteryService extends SystemService {
                         false, this, UserHandle.USER_ALL);
             }
 
+            // Multiple LEDs enabled
+            if (mMultipleNotificationLeds) {
+                resolver.registerContentObserver(Settings.System.getUriFor(
+                        Settings.System.NOTIFICATION_LIGHT_MULTIPLE_LEDS_ENABLE),
+                        false, this, UserHandle.USER_ALL);
+            }
+
             // Light colors
             if (mMultiColorLed) {
                 // Register observer if we have a multi color led
@@ -1161,6 +1177,13 @@ public final class BatteryService extends SystemService {
                 mNotificationLedBrightnessLevel = Settings.System.getInt(resolver,
                         Settings.System.NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL,
                         LIGHT_BRIGHTNESS_MAXIMUM);
+            }
+
+            // Multiple LEDs enabled
+            if (mMultipleNotificationLeds) {
+                mMultipleLedsEnabled = Settings.System.getInt(resolver,
+                        Settings.System.NOTIFICATION_LIGHT_MULTIPLE_LEDS_ENABLE,
+                        mMultipleNotificationLeds ? 1 : 0) != 0;
             }
 
             updateLedPulse();

--- a/services/core/java/com/android/server/lights/Light.java
+++ b/services/core/java/com/android/server/lights/Light.java
@@ -36,7 +36,7 @@ public abstract class Light {
     public abstract void setBrightness(int brightness, int brightnessMode);
     public abstract void setColor(int color);
     public abstract void setFlashing(int color, int mode, int onMS, int offMS);
-    public abstract void setModes(int brightnessLevel);
+    public abstract void setModes(int brightnessLevel, boolean multipleLeds);
     public abstract void pulse();
     public abstract void pulse(int color, int onMS);
     public abstract void turnOff();

--- a/services/core/java/com/android/server/lights/LightsService.java
+++ b/services/core/java/com/android/server/lights/LightsService.java
@@ -71,9 +71,10 @@ public class LightsService extends SystemService {
         }
 
         @Override
-        public void setModes(int brightnessLevel) {
+        public void setModes(int brightnessLevel, boolean multipleLeds) {
             synchronized (this) {
                 mBrightnessLevel = brightnessLevel;
+                mMultipleLeds = multipleLeds;
                 mModesUpdate = true;
             }
         }
@@ -120,7 +121,7 @@ public class LightsService extends SystemService {
                 Trace.traceBegin(Trace.TRACE_TAG_POWER, "setLight(" + mId + ", " + color + ")");
                 try {
                     setLight_native(mNativePointer, mId, color, mode, onMS, offMS, brightnessMode,
-                            mBrightnessLevel);
+                            mBrightnessLevel, mMultipleLeds ? 1 : 0);
                 } finally {
                     Trace.traceEnd(Trace.TRACE_TAG_POWER);
                 }
@@ -135,6 +136,7 @@ public class LightsService extends SystemService {
         private int mBrightnessLevel;
         private boolean mFlashing;
         private boolean mModesUpdate;
+        private boolean mMultipleLeds;
     }
 
     /* This class implements an obsolete API that was removed after eclair and re-added during the
@@ -222,7 +224,8 @@ public class LightsService extends SystemService {
     private static native void finalize_native(long ptr);
 
     static native void setLight_native(long ptr, int light, int color, int mode,
-            int onMS, int offMS, int brightnessMode, int brightnessLevel);
+            int onMS, int offMS, int brightnessMode, int brightnessLevel,
+            int mMultipleLeds);
 
     private long mNativePointer;
 }

--- a/services/core/java/com/android/server/notification/NotificationManagerService.java
+++ b/services/core/java/com/android/server/notification/NotificationManagerService.java
@@ -225,6 +225,9 @@ public class NotificationManagerService extends SystemService {
     private boolean mAdjustableNotificationLedBrightness;
     private int mNotificationLedBrightnessLevel = LIGHT_BRIGHTNESS_MAXIMUM;
 
+    private boolean mMultipleNotificationLeds;
+    private boolean mMultipleLedsEnabledSetting = false;
+
     private boolean mScreenOnEnabled = false;
     private boolean mScreenOnDefault = false;
 
@@ -998,6 +1001,11 @@ public class NotificationManagerService extends SystemService {
                         Settings.System.NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL),
                         false, this, UserHandle.USER_ALL);
             }
+            if (mMultipleNotificationLeds) {
+                resolver.registerContentObserver(Settings.System.getUriFor(
+                        Settings.System.NOTIFICATION_LIGHT_MULTIPLE_LEDS_ENABLE),
+                        false, this, UserHandle.USER_ALL);
+            }
             update(null);
         }
 
@@ -1042,6 +1050,13 @@ public class NotificationManagerService extends SystemService {
                 mNotificationLedBrightnessLevel = Settings.System.getIntForUser(resolver,
                         Settings.System.NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL,
                         LIGHT_BRIGHTNESS_MAXIMUM, UserHandle.USER_CURRENT);
+            }
+
+            // Multiple LEDs enabled
+            if (mMultipleNotificationLeds) {
+                mMultipleLedsEnabledSetting = (Settings.System.getIntForUser(resolver,
+                        Settings.System.NOTIFICATION_LIGHT_MULTIPLE_LEDS_ENABLE,
+                        mMultipleNotificationLeds ? 1 : 0, UserHandle.USER_CURRENT) != 0);
             }
 
             // Notification lights with screen on
@@ -1178,6 +1193,8 @@ public class NotificationManagerService extends SystemService {
 
         mAdjustableNotificationLedBrightness = resources.getBoolean(
                 com.android.internal.R.bool.config_adjustableNotificationLedBrightness);
+        mMultipleNotificationLeds = resources.getBoolean(
+                com.android.internal.R.bool.config_multipleNotificationLeds);
 
         mUseAttentionLight = resources.getBoolean(R.bool.config_useAttentionLight);
 
@@ -3158,7 +3175,8 @@ public class NotificationManagerService extends SystemService {
             }
 
             // update the LEDs modes variables
-            mNotificationLight.setModes(mNotificationLedBrightnessLevel);
+            mNotificationLight.setModes(mNotificationLedBrightnessLevel,
+                    mMultipleLedsEnabledSetting);
 
             if (mNotificationPulseEnabled) {
                 // pulse repeatedly

--- a/services/core/jni/com_android_server_lights_LightsService.cpp
+++ b/services/core/jni/com_android_server_lights_LightsService.cpp
@@ -112,7 +112,7 @@ static void finalize_native(JNIEnv *env, jobject clazz, jlong ptr)
 
 static void setLight_native(JNIEnv *env, jobject clazz, jlong ptr,
         jint light, jint colorARGB, jint flashMode, jint onMS, jint offMS, jint brightnessMode,
-        jint brightnessLevel)
+        jint brightnessLevel, jint multipleLeds)
 {
     Devices* devices = (Devices*)ptr;
     light_state_t state;
@@ -137,6 +137,8 @@ static void setLight_native(JNIEnv *env, jobject clazz, jlong ptr,
     state.flashOnMS = onMS;
     state.flashOffMS = offMS;
     state.brightnessMode = brightnessMode;
+    state.ledsModes = 0 |
+                      (multipleLeds ? LIGHT_MODE_MULTIPLE_LEDS : 0);
 
     {
         ALOGD_IF_SLOW(50, "Excessive delay setting light");
@@ -147,7 +149,7 @@ static void setLight_native(JNIEnv *env, jobject clazz, jlong ptr,
 static JNINativeMethod method_table[] = {
     { "init_native", "()J", (void*)init_native },
     { "finalize_native", "(J)V", (void*)finalize_native },
-    { "setLight_native", "(JIIIIIII)V", (void*)setLight_native },
+    { "setLight_native", "(JIIIIIIII)V", (void*)setLight_native },
 };
 
 int register_android_server_LightsService(JNIEnv *env)


### PR DESCRIPTION
Implement the support of a multiple LEDs settings.

The setting is deactivated by default
and will be ignored by the unimplemented phones.
Current LibLights will simply not use the new variable.

Changes includes :
  frameworks/base
  hardware/libhardware
  packages/Apps/Settings

Change-Id: Ie8712c13e43f823996f10ca83b4a9f95fb750e96
Signed-off-by: AdrianDC radian.dc@gmail.com
