### PR TITLE
AssetAtlasService: fix a potential race condition

### DIFF
--- a/services/core/java/com/android/server/AssetAtlasService.java
+++ b/services/core/java/com/android/server/AssetAtlasService.java
@@ -416,10 +416,18 @@ public class AssetAtlasService extends IAssetAtlas.Stub {
                 new Thread(worker, "Atlas Worker #" + (i + 1)).start();
             }
 
+            boolean isAllWorkerFinished;
             try {
-                signal.await(10, TimeUnit.SECONDS);
+                isAllWorkerFinished = signal.await(10, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 Log.w(LOG_TAG, "Could not complete configuration computation");
+                return null;
+            }
+
+            if (!isAllWorkerFinished) {
+                // We have to abort here, otherwise the async updates on "results" would crash the
+                // sort later.
+                Log.w(LOG_TAG, "Could not complete configuration computation before timeout.");
                 return null;
             }
         }


### PR DESCRIPTION
Backported from marshmallow-release.

Currently worker threads in computeBestConfiguration may NOT completely
finish before timeout.  But the code will start using the result while
the worker threads are still working on the same object.  This may
cause exceptions.

b/19966623

Change-Id: I62ffcb796d648891ee339b6a978f575ebad8352b
